### PR TITLE
Fixed stream write unexpected crash changing ip and added new HWID maker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,17 +17,15 @@ include = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aes = "0.6.0"
+aes = "0.7.4"
 block-modes = "0.8.1"
 rand = "0.8.3"
-md5 = "0.7.0"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
-bcrypt = "0.9.0"
+bcrypt = "0.10.1"
 itertools = "0.10.0"
-hex = "0.4.2"
+machineid-rs = "1.1.0"
 chrono = { version = "0.4.19", features = ["serde"] }
-sysinfo = "0.16.4"
 base64 = "0.13.0"
 openssl = { version = "0.10.35", features = ["vendored"] }
 openssl-sys = "0.9.65"

--- a/src/client.rs
+++ b/src/client.rs
@@ -133,13 +133,18 @@ impl Client {
         buf.append(&mut p_buf);
         buf.push(b'\n');
 
-        stream.write_all(buf.as_slice()).expect("write to server");
-
+        let write_res = stream.write_all(buf.as_slice());
+        if let Err(_) = write_res{
+            return AuthResponse::default();
+        }
         let mut buf: [u8; 512] = [0; 512];
-        stream.read(&mut buf).expect("read");
+        let read_res = stream.read(&mut buf);
+        if let Err(_) = read_res{
+            return AuthResponse::default();
+        }
         let mut vb = Vec::from(buf);
         if !(PacketType::Response as u8).eq(&vb[0]) {
-            return Default::default();
+            return AuthResponse::default();
         }
         vb.remove(0);
         let msg = std::str::from_utf8(vb.as_slice()).expect("xxx");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,20 +1,8 @@
+use machineid_rs::{Encryption, IdBuilder};
 
-use sysinfo::SystemExt;
-
-pub fn get_id() -> std::string::String {
-    let system = sysinfo::System::new_all();
-
-    let disk_count = system.get_disks().len();
-    let cpu_count = system.get_physical_core_count().unwrap_or(4);
-    let ram_count = system.get_total_memory();
-    let os_name = system
-        .get_long_os_version()
-        .unwrap_or_else(|| String::from(""));
-    let host_name = system.get_host_name().unwrap_or_else(|| String::from(""));
-    let payload = format!(
-        "{}-{}-{}-{}-{}",
-        disk_count, cpu_count, ram_count, os_name, host_name
-    );
-    let dig = md5::compute(payload);
-    hex::encode(dig.0.iter().map(|x| *x as char).collect::<String>())
+pub(crate) fn get_id() -> std::string::String {
+    let mut builder = IdBuilder::new(Encryption::SHA256);
+    builder.add_drive_serial().add_cpu_cores().add_machine_name()
+    .add_os_name().add_system_id();
+    builder.build("QuartzAuth")
 }


### PR DESCRIPTION
There seems to be a problem with the actual version when changing ip (with a VPN for example) and it crashes with **code: 10054, kind: ConnectionReset, message: "An existing connection was forcibly closed by the remote host."**

I changed the expect method and implemented an error check that returns a default AuthResponse instead of crashing.
Also i added my package [machineid-rs](https://github.com/Taptiive/machineid-rs) that generates a more reliable hwid than the actual one.