### PR TITLE
Updated crate version and fixed linux support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qauth"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Zertex <zertex@quartzinc.space>"]
 edition = "2018"
 description = "Client library for the QuartzAuth API"
@@ -24,7 +24,7 @@ serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
 bcrypt = "0.10.1"
 itertools = "0.10.0"
-machineid-rs = "1.1.0"
+machineid-rs = "1.1.1"
 chrono = { version = "0.4.19", features = ["serde"] }
 base64 = "0.13.0"
 openssl = { version = "0.10.35", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qauth"
 version = "0.1.3"
-authors = ["Zertex <zertex@quartzinc.space>"]
+authors = ["Zertex <zertex@quartzinc.space>", "Taptiive <aalexius912@gmail.com>"]
 edition = "2018"
 description = "Client library for the QuartzAuth API"
 homepage = "https://auth.quartzinc.space"

--- a/src/client.rs
+++ b/src/client.rs
@@ -134,12 +134,12 @@ impl Client {
         buf.push(b'\n');
 
         let write_res = stream.write_all(buf.as_slice());
-        if let Err(_) = write_res{
+        if write_res.is_err(){
             return AuthResponse::default();
         }
         let mut buf: [u8; 512] = [0; 512];
         let read_res = stream.read(&mut buf);
-        if let Err(_) = read_res{
+        if read_res.is_err(){
             return AuthResponse::default();
         }
         let mut vb = Vec::from(buf);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ use machineid_rs::{Encryption, IdBuilder};
 
 pub(crate) fn get_id() -> std::string::String {
     let mut builder = IdBuilder::new(Encryption::SHA256);
-    builder.add_drive_serial().add_cpu_cores().add_machine_name()
-    .add_os_name().add_system_id();
+    builder.add_cpu_cores().add_machine_name()
+    .add_os_name().add_system_id().add_cpu_id();
     builder.build("QuartzAuth")
 }


### PR DESCRIPTION
I found a big bug on the machineid-rs code with linux support so i updated the crate and now it should be working. Also i replaced the error checking with the .is_err method.

Make sure to do a cargo publish because i changed the version from Cargo.toml