### PR TITLE
Fixed program crashes when a default response is returned

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qauth"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Zertex <zertex@quartzinc.space>", "Taptiive <aalexius912@gmail.com>"]
 edition = "2018"
 description = "Client library for the QuartzAuth API"
@@ -24,7 +24,7 @@ serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
 bcrypt = "0.10.1"
 itertools = "0.10.0"
-machineid-rs = "1.1.1"
+machineid-rs = "1.1.5"
 chrono = { version = "0.4.19", features = ["serde"] }
 base64 = "0.13.0"
 openssl = { version = "0.10.35", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qauth"
 version = "0.1.3"
-authors = ["Zertex <zertex@quartzinc.space>"]
+authors = ["Zertex <zertex@quartzinc.space>", "Taptiive <aalexius912@gmail.com>"]
 edition = "2018"
 description = "Client library for the QuartzAuth API"
 homepage = "https://auth.quartzinc.space"

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -45,7 +45,7 @@ pub struct HeartBeat {
     pub(crate) ad: AuthData,
 }
 
-#[derive(serde::Deserialize, Clone, Debug)]
+#[derive(serde::Deserialize, Clone, Debug, PartialEq)]
 pub struct AuthResponse {
     pub status: String,
     pub message: String,
@@ -53,6 +53,12 @@ pub struct AuthResponse {
     pub arr_data: Option<HashMap<String, String>>,
     #[serde(deserialize_with = "deserialize_from_str")]
     pub expiry: DateTime<FixedOffset>,
+}
+
+impl AuthResponse{
+    pub fn is_default(&self) -> bool{
+        Self::default().eq(self)
+    }
 }
 
 impl Default for AuthResponse {


### PR DESCRIPTION
Right now every single default response is treated as an invalid one, so if there is any stream writing or reading error the program will crash.

I added a method to check if the response is default and changed the return value when the response does not include PacketType::Response.