### PR TITLE
Retriable approach to prevent vpn changes crashing the auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 Cargo.lock
 /.idea
+qauth.iml
+.deepsource.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
 bcrypt = "0.10.1"
 itertools = "0.10.0"
-machineid-rs = "1.1.1"
+machineid-rs = "1.1.5"
 chrono = { version = "0.4.19", features = ["serde"] }
 base64 = "0.13.0"
 openssl = { version = "0.10.35", features = ["vendored"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qauth"
 version = "0.1.5"
-authors = ["Zertex <zertex@quartzinc.space>", "Taptiive <aalexius912@gmail.com>"]
+authors = ["Zertex <zertex@quartzinc.space>", "Taptiive <tap@taptiive.com>"]
 edition = "2018"
 description = "Client library for the QuartzAuth API"
 homepage = "https://auth.quartzinc.space"
@@ -13,18 +13,19 @@ include = [
     "**/*.rs",
     "Cargo.toml",
 ]
+categories = ["api-bindings"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 aes = "0.7.4"
 block-modes = "0.8.1"
-rand = "0.8.3"
+rand = "0.8.4"
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0.62"
 bcrypt = "0.10.1"
 itertools = "0.10.0"
-machineid-rs = "1.1.5"
+machineid-rs = "1.2.1"
 chrono = { version = "0.4.19", features = ["serde"] }
 base64 = "0.13.0"
 openssl = { version = "0.10.35", features = ["vendored"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -156,13 +156,13 @@ impl Client {
             );
 
             if !x.status.eq("success") {
-                /*if let Some(sock_addr) = SocketAddr::from_str(format!("{}:7005", SERVER_LIST.first().unwrap()).as_str())
+                if let Some(sock_addr) = SocketAddr::from_str(format!("{}:7005", SERVER_LIST.first().unwrap()).as_str())
                     .ok() {
                     if let Ok(s) = TcpStream::connect(&sock_addr) {
                         stream = s;
                         continue;
                     }
-                }*/
+                }
                 println!("Suspicious activity detected.");
                 exit(0);
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use openssl::symm::{Cipher, Crypter, Mode};
+use rand::prelude::SliceRandom;
 
 #[derive(Clone, Debug)]
 pub struct AuthServerError;
@@ -156,15 +157,29 @@ impl Client {
             );
 
             if !x.status.eq("success") {
-                if let Some(sock_addr) = SocketAddr::from_str(format!("{}:7005", SERVER_LIST.first().unwrap()).as_str())
-                    .ok() {
-                    if let Ok(s) = TcpStream::connect(&sock_addr) {
-                        stream = s;
-                        continue;
+                let mut rng = thread_rng();
+                let random_server  = SERVER_LIST.choose(&mut rng).unwrap();
+                if let Ok(sock_addr) = SocketAddr::from_str(format!("{}:7005", random_server).as_str()){
+                    let mut s = None;
+                    for _ in 0..5{
+                        if let Ok(new_stream) = TcpStream::connect(sock_addr){
+                            s = Some(new_stream);
+                            break
+                        }
+                        //If the stream connection failed, retry it after 2 seconds
+                        std::thread::sleep(Duration::from_secs(2));
+                    }
+                    match s{
+                        Some(fixed_stream) => {
+                            stream = fixed_stream;
+                            continue;
+                        },
+                        None => {
+                            println!("Suspicious activity detected.");
+                            exit(0);
+                        }
                     }
                 }
-                println!("Suspicious activity detected.");
-                exit(0);
             }
             std::thread::sleep(Duration::from_secs(5));
         }
@@ -215,7 +230,7 @@ impl Client {
         loop {
             let mut buf: [u8; 8192] = [0; 8192];
             match stream.read(&mut buf) {
-                Ok(n) => {
+                Ok(_) => {
                     recv_buf.extend_from_slice(&buf);
                     if buf.contains(&('\n' as u8)) {
                         break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ mod tests {
             String::from("0.0.1"),
         );
         assert!(client.is_ok(), "{}", true);
-        let mut client = client.unwrap();
+        let client = client.unwrap();
 
         let _resp = client.login(String::from("user"), String::from("password"));
         assert!(_resp.status.eq("success"), "{}", true);
@@ -71,6 +71,19 @@ mod tests {
         let var = client.all_variables();
         assert!(var.get("test").unwrap().eq("test"), "{}", true);
         assert!(var.get("test1").unwrap().eq("testing"), "{}", true);
+    }
+
+    #[test]
+    fn vpn_test(){
+        use std::time::Duration;
+        let client = Client::new(
+            "Ol8Y17q7MNe5HPWUhKy0wIhLsuNGtabtazVXpfq37vrmYoY3dDjUTvOyAEHKG47K".into(),
+            "OLhoem4vyvTKFzk4EIiXcMRWZ8Fr5RkK".into(),
+            "1.0".into()
+        ).unwrap();
+        let _resp = client.login("test".into(), "test".into());
+        //Sleep 2 minutes to connect a VPN and check for crashes
+        std::thread::sleep(Duration::from_secs(120));
     }
 }
 


### PR DESCRIPTION
I added retries to the heartbeat code in case the status is not success. This might prevent more cases of disconnections due to a vpn change.